### PR TITLE
CI: update Actions versions from 3 -> 4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Code checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
     - name: Install dependencies

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,11 +8,11 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -128,10 +128,10 @@ jobs:
           echo "NODE_OPTIONS=--dns-result-order=ipv4first" >> $GITHUB_ENV
 
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install NodeJS ${{ inputs.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
         node-version: [ 18.x, 20.x ]
     steps:
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install NodeJS ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/windows-test-command-dispatch.yml
+++ b/.github/workflows/windows-test-command-dispatch.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Dispatch windows-test command
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@v4
         with:
           token: ${{ secrets.REPO_TOKEN }}
           commands: windows-test

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -25,14 +25,14 @@ jobs:
             })
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
       - name: Install NodeJS 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 


### PR DESCRIPTION
V3 actions print out warnings about them being run in deprecated Node.js version. Update to V4 to remedy that.